### PR TITLE
Correct errors in titles.

### DIFF
--- a/from-scout-mods/0012_000060_000460_0000.mods.xml
+++ b/from-scout-mods/0012_000060_000460_0000.mods.xml
@@ -6,12 +6,12 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
    <identifier type="local">0012_000060_000460_0000</identifier>
    <titleInfo>
-      <title>Letter, Lyman C. Draper in Madison, Wis., to J.G.M. Ramsey in Knoxville, Tenn. 1880 Aug. 12</title>
+      <title>Letter, Anson Nelson in Nashville, Tenn., to J.G.M. Ramsey in Knoxville, Tenn., 1880 March 18</title>
    </titleInfo>
-   <abstract>1880 Aug. 12 Lyman C. Draper, Madison, Wis., to J.G.M. Ramsey, Knoxville, Tenn. Presents evidence showing that very few Tennesseans were at the Cowpens. Believes that only four Tennesseans took part and these were volunteers. Mentions that a sketch of the writer's life has just been written.</abstract>
+   <abstract>1880 March 18 Anson Nelson, City Treasurer, to J.G.M. Ramsey, Knoxville, Tenn. Mentions that Lyman C. Draper is invited to the Centennial celebration.</abstract>
    <originInfo>
-      <dateCreated>1880-08-12</dateCreated>
-      <dateCreated encoding="edtf">1880-08-12</dateCreated>
+      <dateCreated>1880-03-18</dateCreated>
+      <dateCreated encoding="edtf">1880-03-18</dateCreated>
    </originInfo>
    <name>
       <namePart>Nelson, Anson, 1821-1892</namePart>

--- a/from-scout-mods/0012_000070_000200_0000.mods.xml
+++ b/from-scout-mods/0012_000070_000200_0000.mods.xml
@@ -6,7 +6,7 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
    <identifier type="local">0012_000070_000200_0000</identifier>
    <titleInfo>
-      <title>Letter, M.S. Temple in Greeneville, Tenn., to O.P. Temple in Knoxville, Tenn., 1863 April 14</title>
+      <title>Letter, M.S. Temple in Greeneville, Tenn., to O.P. Temple in Knoxville, Tenn., 1864 April 14</title>
    </titleInfo>
    <abstract>In this letter dated April 14, 1864 M. S. Temple in Greeneville, Tenn. writes to O.P. Temple in Knoxville, Tenn. about salt, business and signing a petition for the release of arrested men.</abstract>
    <originInfo>

--- a/from-scout-mods/0012_000078_000200_0000.mods.xml
+++ b/from-scout-mods/0012_000078_000200_0000.mods.xml
@@ -6,7 +6,7 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
    <identifier type="local">0012_000078_000200_0000</identifier>
    <titleInfo>
-      <title>Letter of Zalmon S. Main in Memphis, Tenn. to P. S. Lincoln in Cincinnati, Ohio, 1862 August 7</title>
+      <title>Letter, John McNickle Laird in Knoxville, Tenn., to Mrs. Julia Laird in New Bloomfield, Penn., 1863 December 8</title>
    </titleInfo>
    <abstract>In this letter, dated December 8th, 1863 John M. Laird, near Knoxville, Tenn. writes to his mother in New Bloomfield, Penn. concerning the war and how the soldiers took chickens, sheep, cattle, flour and more from those who had seceded. In his letter, he refers to these traitors as "Secesh." His unit had marched 130 to 140 miles in ten days in order to arrive within two miles of Knoxville, Tenn.</abstract>
    <originInfo>

--- a/from-scout-mods/0012_000092_000218_0000.mods.xml
+++ b/from-scout-mods/0012_000092_000218_0000.mods.xml
@@ -6,7 +6,7 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
    <identifier type="local">0012_000092_000218_0000</identifier>
    <titleInfo>
-      <title>Letter, Mangum Cregmile in Stillwell Corner to Southgate Cregmile, 1865, April 6</title>
+      <title>Letter, Mangum Cregmile in Stillwell Corner to Southgate Cregmile, 1865, April 26</title>
    </titleInfo>
    <abstract>1865 April 26 Seventeen year old Mangum Cregmile in Stillwell's Corner, Ohio, to his brother Southgate. Assures him that all is well there. Having recently moved into a new place, he knows no one and there is little to do; but, he plans to move again as soon as possible and get a well paying job. Would rather learn a trade than farm but has no preference right now. Sharing good news, he describes the excitement, especially in Cincinnati, over Richmond, the Confederate capitol, finally falling to the Federals; but has also received news of a local boy being killed. Encourages him about his wound and asks him to write soon.</abstract>
    <originInfo>

--- a/from-scout-mods/0012_000092_000218_0000.mods.xml
+++ b/from-scout-mods/0012_000092_000218_0000.mods.xml
@@ -10,8 +10,8 @@
    </titleInfo>
    <abstract>1865 April 26 Seventeen year old Mangum Cregmile in Stillwell's Corner, Ohio, to his brother Southgate. Assures him that all is well there. Having recently moved into a new place, he knows no one and there is little to do; but, he plans to move again as soon as possible and get a well paying job. Would rather learn a trade than farm but has no preference right now. Sharing good news, he describes the excitement, especially in Cincinnati, over Richmond, the Confederate capitol, finally falling to the Federals; but has also received news of a local boy being killed. Encourages him about his wound and asks him to write soon.</abstract>
    <originInfo>
-      <dateCreated>1865-04-06</dateCreated>
-      <dateCreated encoding="edtf">1865-04-06</dateCreated>
+      <dateCreated>1865-04-26</dateCreated>
+      <dateCreated encoding="edtf">1865-04-26</dateCreated>
    </originInfo>
    <name>
       <namePart>Cregmile, Mangum, 1848-1917</namePart>

--- a/from-scout-mods/0012_002414_000241_0000.mods.xml
+++ b/from-scout-mods/0012_002414_000241_0000.mods.xml
@@ -6,7 +6,7 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
    <identifier type="local">0012_002414_000241_0000</identifier>
    <titleInfo>
-      <title>Letter, Daniel Phoenix in New York, N.Y. to Ebenezer Hazard.,1979 Aug. 17</title>
+      <title>Letter, Daniel Phoenix in New York, N.Y. to Ebenezer Hazard, 1797 Aug. 17</title>
    </titleInfo>
    <abstract/>
    <originInfo>

--- a/from-scout/0012_000060_000460_0000.xml
+++ b/from-scout/0012_000060_000460_0000.xml
@@ -29,15 +29,13 @@
          </publicationStmt>
          <sourceDesc>
             <bibl>
-               <title>Letter, Lyman C. Draper in Madison, Wis., to J.G.M. Ramsey in Knoxville, Tenn. 1880 Aug. 12</title>
-               <date>1880-08-12</date>
+               <title>Letter, Anson Nelson in Nashville, Tenn., to J.G.M. Ramsey in Knoxville, Tenn., 1880 March 18<</title>
+               <date>1880-03-18</date>
                <author>
                   <name>Nelson, Anson, 1821-1892</name>
                </author>
                <extent>3  digital images;  1 envelope, 2 p.</extent>
-               <note type="abstract">1880 Aug. 12 Lyman C. Draper, Madison, Wis., to J.G.M. Ramsey, Knoxville, Tenn. Presents evidence showing that very few Tennesseans were at the Cowpens. Believes that only four Tennesseans took part and these were volunteers. Mentions that a sketch of the writer&apos;s life has just been written. 
-
-</note>
+               <note type="abstract">1880 March 18 Anson Nelson, City Treasurer, to J.G.M. Ramsey, Knoxville, Tenn. Mentions that Lyman C. Draper is invited to the Centennial celebration.</note>
                <note type="collection">James Gettys McGready Ramsey Papers</note>
                <note type="manuscript">MS.0253</note>
             </bibl>

--- a/from-scout/0012_000070_000200_0000.xml
+++ b/from-scout/0012_000070_000200_0000.xml
@@ -28,8 +28,8 @@
          </publicationStmt>
          <sourceDesc>
             <bibl>
-               <title>Letter, M.S. Temple in Greeneville, Tenn., to O.P. Temple in Knoxville, Tenn., 1863 April 14</title>
-               <date>1863-04-14</date>
+               <title>Letter, M.S. Temple in Greeneville, Tenn., to O.P. Temple in Knoxville, Tenn., 1864 April 14</title>
+               <date>1864-04-14</date>
                <author>
                   <name> Temple, M.S.</name>
                </author>

--- a/from-scout/0012_000092_000218_0000.xml
+++ b/from-scout/0012_000092_000218_0000.xml
@@ -28,8 +28,8 @@
          </publicationStmt>
          <sourceDesc>
             <bibl>
-               <title>Letter, Mangum Cregmile in Stillwell Corner to Southgate Cregmile, 1865, April 6</title>
-               <date>1865-04-06</date>
+               <title>Letter, Mangum Cregmile in Stillwell Corner to Southgate Cregmile, 1865, April 26</title>
+               <date>1865-04-26</date>
                <author>
                   <name>Cregmile, Mangum, 1848-1917</name>
                </author>

--- a/from-scout/0012_002414_000241_0000.xml
+++ b/from-scout/0012_002414_000241_0000.xml
@@ -6,7 +6,7 @@
          <titleStmt>
             <title>Letter,
 					<name>Daniel Phoenix</name>
-				                    in New York, N.Y. to Ebenezer Hazard.,<date when="1797-08-17">1979 Aug. 17</date>
+				                    in New York, N.Y. to Ebenezer Hazard,<date when="1797-08-17">1797 Aug. 17</date>
             </title>
             <respStmt>
                <resp>Responsible for machine-readable version</resp>

--- a/from-scout/0012_002414_000241_0000.xml
+++ b/from-scout/0012_002414_000241_0000.xml
@@ -29,8 +29,8 @@
          </publicationStmt>
          <sourceDesc>
             <bibl>
-               <title>Letter, Daniel Phoenix in New York, N.Y. to Ebenezer Hazard.,1979 Aug. 17</title>
-               <date when="1797-08-17">1979 Aug. 17</date>
+               <title>Letter, Daniel Phoenix in New York, N.Y. to Ebenezer Hazard, 1797 Aug. 17</title>
+               <date when="1797-08-17">1797 Aug. 17</date>
                <author>
                   <name type="person">Daniel Phoenix</name>
                </author>

--- a/non-scout-mods/0012_000060_000421_0000.mods.xml
+++ b/non-scout-mods/0012_000060_000421_0000.mods.xml
@@ -6,7 +6,7 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
    <identifier type="local">0012_000060_000421_0000</identifier>
    <titleInfo>
-      <title>Printed circular, J.G.M. Ramsey in Knoxville, Tenn., to Henry Ramsey Lenoir in Lenoirs, Tenn. 1874 June 161874 June 16</title>
+      <title>Printed circular, J.G.M. Ramsey in Knoxville, Tenn., to Henry Ramsey Lenoir in Lenoirs, Tenn. 1874 June 16</title>
    </titleInfo>
    <abstract/>
    <originInfo>

--- a/non-scout-mods/0012_000826_000201_0000.mods.xml
+++ b/non-scout-mods/0012_000826_000201_0000.mods.xml
@@ -6,7 +6,7 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
    <identifier type="local">0012_000826_000201_0000</identifier>
    <titleInfo>
-      <title>Postcard to Miss Gertie Calahan in Asheville, N.C., 1916 Aug. 171916 Aug. 17</title>
+      <title>Postcard to Miss Gertie Calahan in Asheville, N.C., 1916 Aug. 17</title>
    </titleInfo>
    <abstract/>
    <originInfo>

--- a/non-scout/processed-files/READY/0012_000060_000421_0000/0012_000060_000421_0000.xml
+++ b/non-scout/processed-files/READY/0012_000060_000421_0000/0012_000060_000421_0000.xml
@@ -29,7 +29,7 @@
       </publicationStmt>
       <sourceDesc>
         <bibl>
-          <title>Printed circular, J.G.M. Ramsey in Knoxville, Tenn., to Henry Ramsey Lenoir in Lenoirs, Tenn. 1874 June 161874 June 16</title>
+          <title>Printed circular, J.G.M. Ramsey in Knoxville, Tenn., to Henry Ramsey Lenoir in Lenoirs, Tenn. 1874 June 16</title>
           <date when="1874-06-16">1874 June 16</date>
           <author>
             <name type="person">J.G.M. Ramsey</name>

--- a/non-scout/processed-files/READY/0012_000060_000421_0000/0012_000060_000421_0000.xml
+++ b/non-scout/processed-files/READY/0012_000060_000421_0000/0012_000060_000421_0000.xml
@@ -6,7 +6,7 @@
       <titleStmt>
         <title>Printed circular,
 					<name>J.G.M. Ramsey</name>
-				                   in Knoxville, Tenn., to Henry Ramsey Lenoir in Lenoirs, Tenn. 1874 June 16<date when="1874-06-16">1874 June 16</date>
+				                   in Knoxville, Tenn., to Henry Ramsey Lenoir in Lenoirs, Tenn. <date when="1874-06-16">1874 June 16</date>
             </title>
         <respStmt>
           <resp>Responsible for machine-readable version</resp>

--- a/non-scout/processed-files/READY/0012_000826_000201_0000/0012_000826_000201_0000.xml
+++ b/non-scout/processed-files/READY/0012_000826_000201_0000/0012_000826_000201_0000.xml
@@ -29,7 +29,7 @@
       </publicationStmt>
       <sourceDesc>
         <bibl>
-          <title>Postcard to Miss Gertie Calahan in Asheville, N.C., 1916 Aug. 171916 Aug. 17</title>
+          <title>Postcard to Miss Gertie Calahan in Asheville, N.C., 1916 Aug. 17</title>
           <date when="1916-08-17">1916 Aug. 17</date>
           <author>
             <name type="person">Gertie Calahan</name>


### PR DESCRIPTION
**Jira Issue**: [SCO-57](https://jirautk.atlassian.net/browse/SCO-57)

## What does this Pull Request do?

Corrects errors identified by Laura Romans found in the [attached spreadsheet](https://github.com/utkdigitalinitiatives/spc-tei/files/4646278/Copy.of.TEI_TitlestoFix_20200514.xlsx).

## What's new?

See files changed. Mostly titles contained doubled dates or incorrect dates.

## How should this be tested?

No additional review of the individual changes is needed. I did come across a few things that warrant additional investigation though. For instance, for the adminDB 0012_000060_000460_0000, the [mods.xml file](https://github.com/utkdigitalinitiatives/spc-tei/blob/master/from-scout-mods/0012_000060_000460_0000.mods.xml) and the [.xml file](https://github.com/utkdigitalinitiatives/spc-tei/blob/master/from-scout/0012_000060_000460_0000.xml) did not seem to describe the same letter. This is also the case for 0012_000078_000200_0000 ([mods.xml](https://github.com/utkdigitalinitiatives/spc-tei/blob/master/from-scout-mods/0012_000078_000200_0000.mods.xml) and [.xml](https://github.com/utkdigitalinitiatives/spc-tei/blob/master/from-scout/0012_000078_000200_0000.xml)). We likely need to correct the title for mods.xml and see if there's anything in the transform that could explain assigning the wrong title to a particular adminDB that might've caused additional errors not yet caught. Beyond this, I noticed that several of the edits were not needed in the TEI/.xml file but were neccesary for the mods.xml file.

## Interested parties

@CanOfBees 
